### PR TITLE
test: run e2e tests for async flag

### DIFF
--- a/.github/workflows/containerd.yaml
+++ b/.github/workflows/containerd.yaml
@@ -36,3 +36,15 @@ jobs:
         run: ./hack/ci/test.sh
       - name: Uninstall the CSI Driver
         run: helm uninstall -n kube-system ${HELM_NAME} --wait
+      - name: Upgrade the CSI Driver with async flag
+        run: |
+          helm install ${HELM_NAME} charts/warm-metal-csi-driver -n kube-system \
+            -f ${VALUE_FILE} \
+            --set csiPlugin.image.tag=${IMAGE_TAG} \
+            --set enableAsyncPullMount=true \
+            --wait \
+            --debug
+      - name: Run integration Tests
+        run: ./hack/ci/test.sh
+      - name: Uninstall the CSI Driver
+        run: helm uninstall -n kube-system ${HELM_NAME} --wait

--- a/.github/workflows/cri-o.yaml
+++ b/.github/workflows/cri-o.yaml
@@ -37,3 +37,16 @@ jobs:
         run: ./hack/ci/test.sh
       - name: Uninstall the CSI Driver
         run: helm uninstall -n kube-system ${HELM_NAME} --wait
+      - name: Upgrade the CSI Driver with async flag
+        run: |
+          trap "kubectl -n kube-system describe po" ERR
+          helm install ${HELM_NAME} charts/warm-metal-csi-driver -n kube-system \
+            -f ${VALUE_FILE} \
+            --set csiPlugin.image.tag=${IMAGE_TAG} \
+            --set enableAsyncPullMount=true \
+            --wait \
+            --debug
+      - name: Run integration Tests
+        run: ./hack/ci/test.sh
+      - name: Uninstall the CSI Driver
+        run: helm uninstall -n kube-system ${HELM_NAME} --wait

--- a/.github/workflows/restart-ds-containerd.yaml
+++ b/.github/workflows/restart-ds-containerd.yaml
@@ -35,3 +35,16 @@ jobs:
         run: ./test/integration/restart-ds.sh
       - name: Uninstall the CSI Driver
         run: helm uninstall -n kube-system ${HELM_NAME} --wait
+      - name: Upgrade the CSI Driver with async flag
+        run: |
+          trap "kubectl -n kube-system describe po" ERR
+          helm install ${HELM_NAME} charts/warm-metal-csi-driver -n kube-system \
+            -f ${VALUE_FILE} \
+            --set csiPlugin.image.tag=${IMAGE_TAG} \
+            --set enableAsyncPullMount=true \
+            --wait \
+            --debug      
+      - name: Test volumes between the ds restarted
+        run: ./test/integration/restart-ds.sh
+      - name: Uninstall the CSI Driver
+        run: helm uninstall -n kube-system ${HELM_NAME} --wait

--- a/.github/workflows/restart-ds-crio.yaml
+++ b/.github/workflows/restart-ds-crio.yaml
@@ -35,3 +35,16 @@ jobs:
         run: ./test/integration/restart-ds.sh
       - name: Uninstall the CSI Driver
         run: helm uninstall -n kube-system ${HELM_NAME} --wait
+      - name: Upgrade the CSI Driver with async flag
+        run: |
+          trap "kubectl -n kube-system describe po" ERR
+          helm install ${HELM_NAME} charts/warm-metal-csi-driver -n kube-system \
+            -f ${VALUE_FILE} \
+            --set csiPlugin.image.tag=${IMAGE_TAG} \
+            --set enableAsyncPullMount=true \
+            --wait \
+            --debug      
+      - name: Test volumes between the ds restarted
+        run: ./test/integration/restart-ds.sh
+      - name: Uninstall the CSI Driver
+        run: helm uninstall -n kube-system ${HELM_NAME} --wait


### PR DESCRIPTION
### Why
To run the same e2e tests as existing tests with `--async-pull-mount` flag