### PR TITLE
Some dev experience improvements to consider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 id_rsa*
 .cache
 vendor
+test/integration/metrics-manifests/rendered-test.yaml

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMAGE_BUILDER ?= docker
 IMAGE_BUILD_CMD ?= buildx
 REGISTRY ?= docker.io/warmmetal
 PLATFORM ?= linux/amd64
+KIND ?= kind
 
 export IMG = $(REGISTRY)/csi-image:$(VERSION)
 
@@ -50,6 +51,22 @@ image:
 .PHONY: local
 local:
 	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build --platform=$(PLATFORM) -t $(REGISTRY)/csi-image:$(VERSION) --load .
+
+# builds and loads csi-image into kind registry
+.PHONY: local-kind-load
+local-kind-load:
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build --platform=$(PLATFORM) -t $(REGISTRY)/csi-image:$(VERSION) .
+	kind load docker-image $(REGISTRY)/csi-image:$(VERSION) --name $(KIND)
+
+# installs/upgrades csi-driver into kind via helm
+.PHONY: local-kind-install
+local-kind-install:
+	helm upgrade --install container-image-csi-driver charts/warm-metal-csi-driver -n kube-system -f charts/warm-metal-csi-driver/values.yaml --set csiPlugin.image.tag=$(VERSION) --wait --debug
+
+# removes all images which were directly pushed to kind registry
+.PHONY: local-kind-flush
+local-kind-flush:
+	docker exec -e CONTAINERD_NAMESPACE=k8s.io kind-control-plane bash -c "crictl images -o json | jq '.images[] | select((.repoTags == []) or (.repoTags[] | contains(\"docker.io/warmmetal/container-image-csi-driver-test:simple-fs\"))) | .id' -r > '/tmp/TMPFILE';cat /tmp/TMPFILE | awk '{print \"crictl rmi \" \$$1}' | sh;systemctl restart containerd"
 
 .PHONY: test-deps
 test-deps:

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -1,0 +1,35 @@
+# Kind
+
+This is a temporary dump which can be reconciled with local dev docs as they mature.
+
+```
+make local-kind-flush
+make local-kind-load
+make local-kind-install
+sleep 1
+echo "recreating container image pod to ensure image is current"
+k patch ds -n kube-system container-image-csi-driver-warm-metal-csi-driver-nodeplugin --type=json --patch '[{"op":"add","path":"/spec/template/spec/containers/2/args/6","value":"--async-pull-timeout=10m"}]'
+k patch ds -n kube-system container-image-csi-driver-warm-metal-csi-driver-nodeplugin --type=json --patch '[{"op":"replace","path":"/spec/template/spec/containers/2/args/4","value":"--v=7"}]'
+PODNAME=$(k get po -n kube-system -l=component=nodeplugin --no-headers | cut -f 1 -d " ")
+k delete po -n kube-system ${PODNAME}
+sleep 3
+echo "tailing logs of plugin pod"
+PODNAME=$(k get po -n kube-system -l=component=nodeplugin --no-headers | cut -f 1 -d " ")
+CONTAINERLOG='/tmp/container-image-csi-plugin.log'
+echo "" > ${CONTAINERLOG}
+sleep 1
+k logs -n kube-system -f ${PODNAME} -c csi-plugin | tee ${CONTAINERLOG}&
+k apply -f sample/ephemeral-volume-set.yaml
+k wait --for=condition=complete --timeout=10s job/ephemeral-volume-1
+k wait --for=condition=complete --timeout=1s job/ephemeral-volume-2
+k wait --for=condition=complete --timeout=1s job/ephemeral-volume-3
+k wait --for=condition=complete --timeout=1s job/ephemeral-volume-4
+k wait --for=condition=complete --timeout=1s job/ephemeral-volume-5
+sleep 1
+k delete -f sample/ephemeral-volume-set.yaml
+sleep 3
+echo "**********************************"
+echo "** ctrl+C to kill log streaming **"
+echo "**********************************"
+fg
+```

--- a/sample/ephemeral-volume-set.yaml
+++ b/sample/ephemeral-volume-set.yaml
@@ -1,0 +1,164 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ephemeral-volume-1
+spec:
+  template:
+    metadata:
+      name: ephemeral-volume-1
+    spec:
+      containers:
+        - name: ephemeral-volume
+          image: docker.io/warmmetal/container-image-csi-driver-test:check-fs
+          env:
+            - name: TARGET
+              value: /target
+          volumeMounts:
+            - mountPath: /target
+              name: target
+      restartPolicy: Never
+      volumes:
+        - name: target
+          csi:
+            driver: csi-image.warm-metal.tech
+            volumeAttributes:
+              image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
+              # image: "ubuntu:latest" # may want to pull a larger image so parallel pull requests can be seen for continuation
+              # # set pullAlways if you want to ignore local images
+              pullAlways: "false"
+              # # set secret if the image is private
+              # secret: "name of the ImagePullSecret"
+              # secretNamespace: "namespace of the secret"
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ephemeral-volume-2
+spec:
+  template:
+    metadata:
+      name: ephemeral-volume-2
+    spec:
+      containers:
+        - name: ephemeral-volume
+          image: docker.io/warmmetal/container-image-csi-driver-test:check-fs
+          env:
+            - name: TARGET
+              value: /target
+          volumeMounts:
+            - mountPath: /target
+              name: target
+      restartPolicy: Never
+      volumes:
+        - name: target
+          csi:
+            driver: csi-image.warm-metal.tech
+            volumeAttributes:
+              image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
+              # image: "ubuntu:latest" # may want to pull a larger image so parallel pull requests can be seen for continuation
+              # # set pullAlways if you want to ignore local images
+              pullAlways: "false"
+              # # set secret if the image is private
+              # secret: "name of the ImagePullSecret"
+              # secretNamespace: "namespace of the secret"
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ephemeral-volume-3
+spec:
+  template:
+    metadata:
+      name: ephemeral-volume-3
+    spec:
+      containers:
+        - name: ephemeral-volume
+          image: docker.io/warmmetal/container-image-csi-driver-test:check-fs
+          env:
+            - name: TARGET
+              value: /target
+          volumeMounts:
+            - mountPath: /target
+              name: target
+      restartPolicy: Never
+      volumes:
+        - name: target
+          csi:
+            driver: csi-image.warm-metal.tech
+            volumeAttributes:
+              image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
+              # image: "ubuntu:latest" # may want to pull a larger image so parallel pull requests can be seen for continuation
+              # # set pullAlways if you want to ignore local images
+              pullAlways: "false"
+              # # set secret if the image is private
+              # secret: "name of the ImagePullSecret"
+              # secretNamespace: "namespace of the secret"
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ephemeral-volume-4
+spec:
+  template:
+    metadata:
+      name: ephemeral-volume-4
+    spec:
+      containers:
+        - name: ephemeral-volume
+          image: docker.io/warmmetal/container-image-csi-driver-test:check-fs
+          env:
+            - name: TARGET
+              value: /target
+          volumeMounts:
+            - mountPath: /target
+              name: target
+      restartPolicy: Never
+      volumes:
+        - name: target
+          csi:
+            driver: csi-image.warm-metal.tech
+            volumeAttributes:
+              image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
+              # image: "ubuntu:latest" # may want to pull a larger image so parallel pull requests can be seen for continuation
+              # # set pullAlways if you want to ignore local images
+              pullAlways: "false"
+              # # set secret if the image is private
+              # secret: "name of the ImagePullSecret"
+              # secretNamespace: "namespace of the secret"
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ephemeral-volume-5
+spec:
+  template:
+    metadata:
+      name: ephemeral-volume-5
+    spec:
+      containers:
+        - name: ephemeral-volume
+          image: docker.io/warmmetal/container-image-csi-driver-test:check-fs
+          env:
+            - name: TARGET
+              value: /target
+          volumeMounts:
+            - mountPath: /target
+              name: target
+      restartPolicy: Never
+      volumes:
+        - name: target
+          csi:
+            driver: csi-image.warm-metal.tech
+            volumeAttributes:
+              image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
+              # image: "ubuntu:latest" # may want to pull a larger image so parallel pull requests can be seen for continuation
+              # # set pullAlways if you want to ignore local images
+              pullAlways: "false"
+              # # set secret if the image is private
+              # secret: "name of the ImagePullSecret"
+              # secretNamespace: "namespace of the secret"
+  backoffLimit: 0

--- a/sample/ephemeral-volume.yaml
+++ b/sample/ephemeral-volume.yaml
@@ -24,7 +24,7 @@ spec:
             volumeAttributes:
               image: "docker.io/warmmetal/container-image-csi-driver-test:simple-fs"
               # # set pullAlways if you want to ignore local images
-              # pullAlways: "true"
+              pullAlways: "true"
               # # set secret if the image is private
               # secret: "name of the ImagePullSecret"
               # secretNamespace: "namespace of the secret"


### PR DESCRIPTION
This pull request captures changes that I extracted from PR #137 Async pull and moved to a separate dev experience PR for issue #143

One main change relates to kind cluster support. There were various cases where broken logic caused successful mounts because images were cached in kind image repository. I added make targets for building/pushing code images and flushing kind image cached images. I also built up a long set of commands that I needed for iteration and captured them for integration into more complete dev experience docs.

This was the minimum necessary tooling that I required in order to reliably reproduce CI build errors and gain confidence in what was occurring on my local environment as I pursued PR #137.