### PR TITLE
Fix Critical CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warm-metal/container-image-csi-driver
 
-go 1.19
+go 1.21.11
 
 require (
 	github.com/BurntSushi/toml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1490,6 +1490,7 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
What happened?
An orca scan detected the CVE-2024-24790

What are we trying to fix?
Update the go version from 1.20.4 to 1.21.11
Vulnerability_id | Package Name | Vulnerable Version | Patch Version | Type | Severity
| -- | -- | -- | -- | -- | --
CVE-2024-24790 | stdlib | 1.20.4 | 1.21.11, 1.22.4 | gobinary | CRITICAL


Environment
- Kubernetes version: v1.28.9-eks
- CSI driver image and version: docker.io/warmmetal/csi-image [v1.2.3](https://github.com/warm-metal/container-image-csi-driver/releases/tag/v1.2.3