### PR TITLE
fix: avoid using builder cache in integration tests

### DIFF
--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -5,12 +5,21 @@ set -x
 VERSION=$(git rev-parse --short HEAD)
 IMG=docker.io/warmmetal/container-image-csi-driver:${VERSION}
 BUILDER=$(docker buildx ls | grep ci-builderx || true)
-[ "${BUILDER}" != "" ] || docker buildx create \
+
+if [ "${BUILDER}" != "" ]; then
+    docker buildx rm ci-builderx
+fi
+
+docker buildx create \
     --name ci-builderx --driver docker-container \
     --bootstrap \
     --driver-opt image=moby/buildkit:master,network=host
+
 docker buildx use ci-builderx
 docker buildx build -t ${IMG} -o "type=oci,dest=container-image-csi-driver.tar" .
 kind load image-archive container-image-csi-driver.tar -n kind-${GITHUB_RUN_ID}
 docker buildx build --target install-util -o "type=local,dest=_output/" .
+
+# Cleanup builder to avoid caching issues
+docker buildx rm ci-builderx
 set +e


### PR DESCRIPTION
## Motivation
Closes #102 

## Suggested changes
Regarding [this](https://github.com/warm-metal/container-image-csi-driver/issues/102#issuecomment-1875166022) comment -
> But instead of directly disabling caching, we should look into how we can enable smart caches where if the changes are detected in the code/tests only then the caching is disabled.

I tried checking if there's an easy way to enable smart caches, but couldn't find any easily configurable.

The easiest way I found to fix this is to cleanup docker builder, so that the same builder won't be used again.

## Reproducing the issue
In the last few CI builds I found that the same builder was not being used in the consecutive builds. But there's a possibility of that happening if the same actions node is reused again.

I could reproduce the issue locally if the same builder is being used.